### PR TITLE
Bug Fix preventing heat and cool at same time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [New Release]  2017-02-12
+
+### Changed
+- Bug Fix: Fixed a bug where heat and cool can switched on at same time. 
+
 ## [New Release]  2017-02-10
 
 ### Added

--- a/src/BangController.cpp
+++ b/src/BangController.cpp
@@ -24,6 +24,7 @@ BangController::~BangController() {
 
 void BangController::heat(bool _status) {
   if( _status ) {
+    digitalWrite(coolPin, LOW) ;
     digitalWrite(heatPin, HIGH) ;
     status = 1 ;
   }
@@ -36,6 +37,7 @@ void BangController::heat(bool _status) {
 
 void BangController::cool(bool _status) {
   if ( _status ) {
+    digitalWrite(heatPin, LOW) ;
     digitalWrite(coolPin, HIGH) ;
     status = 2 ;
   }


### PR DESCRIPTION
At specific conditions, heat and cool can be set on at same time. Changed the  heat and cool functions to switch off each other when acting. 